### PR TITLE
Added metadata tag.

### DIFF
--- a/src/pef-specification.html
+++ b/src/pef-specification.html
@@ -9,7 +9,7 @@
   <meta name="dc:identifier" content="" />
   <meta name="dc:Title" content="PEF Specification" />
   <meta name="dc:Language" content="SV" />
-  <meta name="dc:Date" content="2007-02-21" />
+  <meta name="dc:Date" content="2020-04-29" />
   <meta name="dc:Publisher" content="TPB" />
   <meta name="wml2dtbook:version" content="1.4.1.1" />
   <meta name="wml2dtbook:date" content="17 January 2007" />
@@ -23,7 +23,7 @@
 <dl>
   <dt><a id="thisVersion" name="thisVersion">This version</a>:</dt>
     <dd><a
-      href="https://braillespecs.github.io/pef/pef-specification.html">https://braillespecs.github.io/pef/pef-specification.html</a>
+      href="https://mtmse.github.io/pef/pef-specification.html">https://mtmse.github.io/pef/pef-specification.html</a>
     </dd>
   <dt>Author:</dt>
     <dd>Joel Håkansson</dd>

--- a/src/pef-specification.html
+++ b/src/pef-specification.html
@@ -50,7 +50,7 @@ Contents</h2>
 
 <div class="toc">
 <ul>
-  <li><a href="#Introducti">Introduction</a> 
+  <li><a href="#Introducti">Introduction</a>
     <ul>
       <li><a href="#What">What is PEF?</a></li>
       <li><a href="#there">Why is PEF Necessary?</a></li>
@@ -63,7 +63,7 @@ Contents</h2>
       <li><a href="#Future">Further Development</a></li>
     </ul>
   </li>
-  <li><a href="#Definition">Definitions</a> 
+  <li><a href="#Definition">Definitions</a>
     <ul>
       <li><a href="#Terminolog">Terminology</a></li>
       <li><a href="#General">General Terms</a></li>
@@ -71,10 +71,10 @@ Contents</h2>
       <li><a href="#Relationsh11">Relationship to Other Specifications</a></li>
     </ul>
   </li>
-  <li><a href="#Normative">Definition of PEF 1.0</a> 
+  <li><a href="#Normative">Definition of PEF 1.0</a>
     <ul>
       <li><a href="#Document">Document Conformance </a></li>
-      <li><a href="#User">User Agent Conformance</a> 
+      <li><a href="#User">User Agent Conformance</a>
         <ul>
           <li><a href="#Processing">Processing Unknown Content</a></li>
         </ul>
@@ -85,7 +85,7 @@ Contents</h2>
       <li><a href="#Internet">Internet Media Type and File Extension</a></li>
     </ul>
   </li>
-  <li><a href="#Elements">Elements</a> 
+  <li><a href="#Elements">Elements</a>
     <ul>
       <li><a href="#pef">pef</a></li>
       <li><a href="#head">head</a></li>
@@ -100,13 +100,13 @@ Contents</h2>
   </li>
   <li><a href="#Error1">Metadata Extension</a></li>
   <li><a href="#Error11">Error Handling</a></li>
-  <li><a href="#Rule">Rule Sets</a> 
+  <li><a href="#Rule">Rule Sets</a>
     <ul>
       <li><a href="#Relax">Relax NG Rule Set</a></li>
       <li><a href="#Schema1">DTD Rule Set</a></li>
     </ul>
   </li>
-  <li><a href="#References">References</a> 
+  <li><a href="#References">References</a>
     <ul>
       <li><a href="#Normative1">Normative References</a></li>
       <li><a href="#Informativ">Informative References</a></li>
@@ -412,7 +412,7 @@ processes unknown content:</p>
 <ol>
   <li>If the unknown contents is an element, all node children, except text
     node children, must be processed. Using XPath in the context of the unknown
-    element, this can be expressed as: 
+    element, this can be expressed as:
     <p><code>node()[not(self::text())]</code></p>
     <p>For example, a user agent should read</p>
     <p><samp xml:space="preserve">...</samp><br />
@@ -644,6 +644,17 @@ the [<a class="nref" href="#ref-dublincore">Dublin Core</a>] namespace.</p>
     <dd>page</dd>
   <dt>Value</dt>
     <dd>A string containing Unicode braille patterns.</dd>
+  <dt>Child elements</dt>
+    <dd>metadata (zero or more)</dd>
+</dl>
+
+<h3 id="metadata">metadata</h3>
+<dl>
+  <dt>Description</dt>
+    <dd>The metadata element defines specific data that is carried through the
+      framework from generators of OBFL.</dd>
+  <dt>Parent element</dt>
+    <dd>row</dd>
 </dl>
 
 <h2 id="Error1">Metadata Extension</h2>
@@ -699,7 +710,7 @@ fallback behaviour is acceptable under the following circumstances:</p>
     <dd>The user agent may disregard volume information and continue
       processing. The user agent may prompt the user before continuing.</dd>
   <dt>The user agent cannot process braille patterns in range 2840-28FF</dt>
-    <dd>The user agent may prompt the user for one of the following actions: 
+    <dd>The user agent may prompt the user for one of the following actions:
       <ol>
         <li>ignore unsupported braille patterns (rows will be shortened)</li>
         <li>replace unsupported braille patterns with a fixed replacement, e.g.

--- a/src/validation/pef-2008-1.rng
+++ b/src/validation/pef-2008-1.rng
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<grammar  
+<grammar
   ns="http://www.daisy.org/ns/2008/pef"
   xmlns="http://relaxng.org/ns/structure/1.0"
   xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -48,7 +48,7 @@
 			</interleave>
 		</element>
 	</define>
-	
+
 	<define name="element.meta">
 		<element name="meta" xmlns:dc="http://purl.org/dc/elements/1.1/">
 			<zeroOrMore>
@@ -175,9 +175,9 @@
 					<ref name="element.any.meta"/>
 				</zeroOrMore>
 			</interleave>
-		</element>	  	
+		</element>
 	</define>
-	
+
 	<define name="element.body">
 		<element name="body">
 			<zeroOrMore>
@@ -193,12 +193,12 @@
 			</interleave>
 		</element>
 	</define>
-	
+
 	<define name="element.volume">
 		<element name="volume">
 			<a:documentation>Defines a volume of embossed braille.</a:documentation>
 			<ref name="attribute.cols"/>
-			<ref name="attribute.rows"/>	
+			<ref name="attribute.rows"/>
 			<ref name="attribute.rowgap"/>
 			<ref name="attribute.duplex"/>
 			<zeroOrMore>
@@ -214,7 +214,7 @@
 			</interleave>
 		</element>
 	</define>
-	
+
 	<define name="element.section">
 		<element name="section">
 			<a:documentation>Defines a section of embossed braille.</a:documentation>
@@ -261,8 +261,21 @@
 			<zeroOrMore>
 				<ref name="attribute.anyExceptDefault"/>
 			</zeroOrMore>
+			<interleave>
+				<zeroOrMore>
+					<ref name="element.metadata"/>
+				</zeroOrMore>
+			</interleave>
 			<ref name="datatype.string.unicode.braille"/>
 		</element>
+	</define>
+
+	<define name="element.metadata">
+		<zeroOrMore>
+			<attribute>
+				<anyName></anyName>
+			</attribute>
+		</zeroOrMore>
 	</define>
 
 	<define name="element.any">
@@ -281,7 +294,7 @@
 			</zeroOrMore>
 		</element>
 	</define>
-	
+
 	<define name="element.any.meta">
 		<element>
 			<anyName>
@@ -315,7 +328,7 @@
 			</anyName>
 		</attribute>
 	</define>
-	
+
 	<define name="attribute.cols">
 		<a:documentation>Defines the width (measured in characters) of page descendants.</a:documentation>
 		<attribute name="cols">
@@ -328,7 +341,7 @@
 			<ref name="attribute.cols"/>
 		</optional>
 	</define>
-	
+
 	<define name="attribute.rows">
 		<a:documentation>Defines the height (measured in characters) of page descendants.</a:documentation>
 		<attribute name="rows">
@@ -341,7 +354,7 @@
 			<ref name="attribute.rows"/>
 		</optional>
 	</define>
-	
+
 	<define name="attribute.rowgap">
 		<a:documentation>Defines the size of a gap between rows (expressed as a multiple of the dot-to-dot height). In practice, this value should be 0 or more for six dot braille and 1 or more for eight dot braille</a:documentation>
 		<attribute name="rowgap">
@@ -352,9 +365,9 @@
 		<a:documentation>Overrides any value defined by ancestors.</a:documentation>
 		<optional>
 			<ref name="attribute.rowgap"/>
-		</optional>	
+		</optional>
 	</define>
-	
+
 	<define name="attribute.duplex">
 		<a:documentation>Defines whether page descendants are intended for duplex printing or not.</a:documentation>
 		<attribute name="duplex">
@@ -365,9 +378,9 @@
 		<a:documentation>Overrides any value defined by ancestors.</a:documentation>
 		<optional>
 			<ref name="attribute.duplex"/>
-		</optional>	
+		</optional>
 	</define>
-	
+
 	<define name="datatype.mime.pef">
 		<choice>
 			<value>application/x-pef+xml</value>
@@ -379,24 +392,24 @@
 			<param name="pattern">([&#x2800;-&#x28FF;])*</param>
 		</data>
 	</define>
-	
-	<define name="datatype.rfc1766">		
+
+	<define name="datatype.rfc1766">
 		<!-- this is in reality rfc3066; supercedes 1766 by this erratum: http://www.w3.org/XML/xml-V10-2e-errata#E11 -->
 		<data type="language"/>
 	</define>
-	
+
 	<define name="datatype.string">
 		<data type="string"/>
 	</define>
-	
+
 	<define name="datatype.boolean">
 		<data type="boolean"/>
-	</define>	
-	
+	</define>
+
 	<define name="datatype.integer">
 		<data type="integer"/>
 	</define>
-		
+
 	<define name="datatype.iso8601.yyyyMmDd">
 		<a:documentation>[ISO8601] subset: requires yyyy-mm-dd
 			format</a:documentation>
@@ -404,13 +417,13 @@
 			<param name="pattern">[0-9]{4}-[0-9]{2}-[0-9]{2}</param>
 		</data>
 	</define>
-	
+
 	<define name="datatype.nonNegativeInteger">
 		<data type="nonNegativeInteger"/>
 	</define>
-	
+
 	<define name="datatype.positiveInteger">
 		<data type="positiveInteger"/>
 	</define>
-	
+
 </grammar>


### PR DESCRIPTION
Issue https://github.com/mtmse/dotify.formatter.impl/issues/25

Description:
Enable the addition of a metadata tag in OBFL to have it available in the PEF output.

Changes:
* Added metadata as a possible child to row.